### PR TITLE
Add FastAPI wrapper for listing GitHub repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Simple Dockerfile for running FastAPI app
+FROM python:3.13-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir uv
+
+COPY requirements.txt .
+RUN uv pip install -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+CMD ["uv", "run", "uvicorn", "fastapi_app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -208,3 +208,31 @@ Current version: **0.2.0**
 - Typer >= 0.12.3
 - Rich >= 13.0.0
 - python-dotenv >= 1.0.0
+
+## FastAPI GitHub API
+
+A simple FastAPI application is included to list your GitHub repositories using your personal access token.
+
+### Local Development
+
+1. Install dependencies:
+   ```bash
+   uv pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```bash
+   uv run uvicorn fastapi_app:app --reload
+   ```
+3. Open your browser at `http://127.0.0.1:8000/docs` to explore the API via Swagger UI.
+
+### Docker
+
+1. Build the image:
+   ```bash
+   docker build -t git-autobot-api .
+   ```
+2. Run the container (pass your token via environment variable):
+   ```bash
+   docker run -e GITHUB_TOKEN=your_token -p 8000:8000 git-autobot-api
+   ```
+3. Visit `http://localhost:8000/docs` for the interactive API documentation.

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -1,0 +1,29 @@
+from typing import List, Optional
+from fastapi import FastAPI, Depends, HTTPException, Query
+from github import Github, GithubException
+from pydantic import BaseModel
+import os
+
+class Repository(BaseModel):
+    name: str
+    full_name: str
+    html_url: str
+
+app = FastAPI(title="Git Autobot GitHub API")
+
+def get_github_client(token: Optional[str] = Query(default=None, description="GitHub personal access token")) -> Github:
+    token = token or os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise HTTPException(status_code=400, detail="GitHub token required")
+    return Github(token)
+
+@app.get("/repos", response_model=List[Repository], summary="List user repositories")
+def list_repositories(gh: Github = Depends(get_github_client)) -> List[Repository]:
+    try:
+        user = gh.get_user()
+        repos = [Repository(name=r.name, full_name=r.full_name, html_url=r.html_url) for r in user.get_repos()]
+        return repos
+    except GithubException as e:
+        status = getattr(e, "status", 500)
+        message = getattr(e, "data", {}).get("message") if hasattr(e, "data") else str(e)
+        raise HTTPException(status_code=status, detail=message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 # Dependencies for Git Autobot
 GitPython>=3.1.40
 PyGithub>=1.59.0
+fastapi>=0.111.0
+uvicorn>=0.30.0
+httpx>=0.27.0
+python-dotenv>=1.0.0

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+from fastapi_app import app
+
+
+def test_list_repositories_returns_repo_list():
+    client = TestClient(app)
+    mock_repo = MagicMock()
+    mock_repo.name = "repo1"
+    mock_repo.full_name = "user/repo1"
+    mock_repo.html_url = "https://github.com/user/repo1"
+
+    mock_user = MagicMock()
+    mock_user.get_repos.return_value = [mock_repo]
+
+    with patch("fastapi_app.Github") as MockGithub:
+        instance = MockGithub.return_value
+        instance.get_user.return_value = mock_user
+
+        response = client.get("/repos", params={"token": "fake"})
+
+    assert response.status_code == 200
+    assert response.json() == [{
+        "name": "repo1",
+        "full_name": "user/repo1",
+        "html_url": "https://github.com/user/repo1"
+    }]

--- a/uv.lock
+++ b/uv.lock
@@ -125,12 +125,13 @@ wheels = [
 
 [[package]]
 name = "git-autobot"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
     { name = "pygithub" },
     { name = "python-dotenv" },
+    { name = "rich" },
     { name = "typer" },
 ]
 
@@ -139,6 +140,7 @@ requires-dist = [
     { name = "gitpython", specifier = ">=3.1.44" },
     { name = "pygithub", specifier = ">=2.6.1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.3" },
 ]
 


### PR DESCRIPTION
## Summary
- add FastAPI app with Pydantic schema to list GitHub repositories
- document local and Docker usage and update dependencies
- provide Dockerfile and tests for the new API

## Testing
- `uv pip install --system -r requirements.txt`
- `uv run pytest` *(fails: NameError and AssertionError in existing tests)*
- `PYTHONPATH=. uv run pytest tests/test_fastapi_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b20fa6f340832db0cd255c0eb236ce