### PR TITLE
Add repository detail endpoints and local clone listing

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -2,28 +2,148 @@ from typing import List, Optional
 from fastapi import FastAPI, Depends, HTTPException, Query
 from github import Github, GithubException
 from pydantic import BaseModel
+from pathlib import Path
 import os
 
+
 class Repository(BaseModel):
+    """Basic repository information returned from the GitHub API."""
+
     name: str
-    full_name: str
+    description: Optional[str]
+    visibility: str
+    default_branch: str
+
+
+class CommitMetadata(BaseModel):
+    """Metadata about a commit."""
+
+    sha: str
+    message: str
+    author: Optional[str]
+    date: Optional[str]
+
+
+class RepositoryDetails(BaseModel):
+    """Detailed repository information."""
+
+    name: str
+    description: Optional[str]
+    visibility: str
+    default_branch: str
+    branches: List[str]
+    last_commit: Optional[CommitMetadata]
+    contributors: List[str]
     html_url: str
+
+
+class ReadmeResponse(BaseModel):
+    """README content."""
+
+    content: str
+
+
+class LocalRepository(BaseModel):
+    """Information about a locally cloned repository."""
+
+    name: str
+    path: str
+
 
 app = FastAPI(title="Git Autobot GitHub API")
 
-def get_github_client(token: Optional[str] = Query(default=None, description="GitHub personal access token")) -> Github:
+
+def get_github_client(
+    token: Optional[str] = Query(default=None, description="GitHub personal access token")
+) -> Github:
     token = token or os.getenv("GITHUB_TOKEN")
     if not token:
         raise HTTPException(status_code=400, detail="GitHub token required")
     return Github(token)
 
+
+BASE_DIR = Path(__file__).resolve().parent
+LOCAL_REPOS_DIR = Path(os.getenv("LOCAL_REPOS_DIR", BASE_DIR.parent / "local_repos")).resolve()
+LOCAL_REPOS_DIR.mkdir(parents=True, exist_ok=True)
+
+
 @app.get("/repos", response_model=List[Repository], summary="List user repositories")
 def list_repositories(gh: Github = Depends(get_github_client)) -> List[Repository]:
     try:
         user = gh.get_user()
-        repos = [Repository(name=r.name, full_name=r.full_name, html_url=r.html_url) for r in user.get_repos()]
+        repos = [
+            Repository(
+                name=r.name,
+                description=r.description,
+                visibility="private" if r.private else "public",
+                default_branch=r.default_branch,
+            )
+            for r in user.get_repos()
+        ]
         return repos
     except GithubException as e:
         status = getattr(e, "status", 500)
         message = getattr(e, "data", {}).get("message") if hasattr(e, "data") else str(e)
         raise HTTPException(status_code=status, detail=message)
+
+
+@app.get("/repos/{name}", response_model=RepositoryDetails, summary="Get repository details")
+def get_repository_details(name: str, gh: Github = Depends(get_github_client)) -> RepositoryDetails:
+    try:
+        repo = gh.get_user().get_repo(name)
+
+        branches = [b.name for b in repo.get_branches()]
+
+        try:
+            commit_obj = repo.get_commits()[0]
+            last_commit = CommitMetadata(
+                sha=commit_obj.sha,
+                message=commit_obj.commit.message,
+                author=getattr(commit_obj.commit.author, "name", None),
+                date=str(getattr(commit_obj.commit.author, "date", None)),
+            )
+        except Exception:
+            last_commit = None
+
+        contributors = [c.login for c in repo.get_contributors()]
+
+        return RepositoryDetails(
+            name=repo.name,
+            description=repo.description,
+            visibility="private" if repo.private else "public",
+            default_branch=repo.default_branch,
+            branches=branches,
+            last_commit=last_commit,
+            contributors=contributors,
+            html_url=repo.html_url,
+        )
+    except GithubException as e:
+        status = getattr(e, "status", 500)
+        message = getattr(e, "data", {}).get("message") if hasattr(e, "data") else str(e)
+        raise HTTPException(status_code=status, detail=message)
+
+
+@app.get("/repos/{name}/readme", response_model=ReadmeResponse, summary="Get repository README")
+def get_repository_readme(name: str, gh: Github = Depends(get_github_client)) -> ReadmeResponse:
+    try:
+        repo = gh.get_user().get_repo(name)
+        readme = repo.get_readme()
+        content = readme.decoded_content.decode("utf-8")
+        return ReadmeResponse(content=content)
+    except GithubException as e:
+        status = getattr(e, "status", 500)
+        if status == 404:
+            raise HTTPException(status_code=404, detail="README not found")
+        message = getattr(e, "data", {}).get("message") if hasattr(e, "data") else str(e)
+        raise HTTPException(status_code=status, detail=message)
+
+
+@app.get("/local/repos", response_model=List[LocalRepository], summary="List local repositories")
+def list_local_repositories() -> List[LocalRepository]:
+    repos: List[LocalRepository] = []
+    if LOCAL_REPOS_DIR.exists():
+        for item in LOCAL_REPOS_DIR.iterdir():
+            if item.is_dir() and (item / ".git").exists():
+                repos.append(LocalRepository(name=item.name, path=str(item)))
+    return repos
+

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1,14 +1,17 @@
 from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
 from fastapi_app import app
+import fastapi_app
 
 
 def test_list_repositories_returns_repo_list():
     client = TestClient(app)
+
     mock_repo = MagicMock()
     mock_repo.name = "repo1"
-    mock_repo.full_name = "user/repo1"
-    mock_repo.html_url = "https://github.com/user/repo1"
+    mock_repo.description = "A repo"
+    mock_repo.private = False
+    mock_repo.default_branch = "main"
 
     mock_user = MagicMock()
     mock_user.get_repos.return_value = [mock_repo]
@@ -16,12 +19,112 @@ def test_list_repositories_returns_repo_list():
     with patch("fastapi_app.Github") as MockGithub:
         instance = MockGithub.return_value
         instance.get_user.return_value = mock_user
-
         response = client.get("/repos", params={"token": "fake"})
 
     assert response.status_code == 200
-    assert response.json() == [{
+    assert response.json() == [
+        {
+            "name": "repo1",
+            "description": "A repo",
+            "visibility": "public",
+            "default_branch": "main",
+        }
+    ]
+
+
+def test_get_repository_details():
+    client = TestClient(app)
+
+    mock_repo = MagicMock()
+    mock_repo.name = "repo1"
+    mock_repo.description = "A repo"
+    mock_repo.private = False
+    mock_repo.default_branch = "main"
+    mock_repo.html_url = "https://github.com/user/repo1"
+
+    branch_main = MagicMock()
+    branch_main.name = "main"
+    branch_dev = MagicMock()
+    branch_dev.name = "dev"
+    mock_repo.get_branches.return_value = [branch_main, branch_dev]
+
+    commit = MagicMock()
+    commit.sha = "abc123"
+    commit.commit = MagicMock()
+    commit.commit.message = "init"
+    commit.commit.author = MagicMock()
+    commit.commit.author.name = "author"
+    commit.commit.author.date = "2024-01-01"
+    mock_repo.get_commits.return_value = [commit]
+
+    contributor = MagicMock()
+    contributor.login = "contrib"
+    mock_repo.get_contributors.return_value = [contributor]
+
+    mock_user = MagicMock()
+    mock_user.get_repo.return_value = mock_repo
+
+    with patch("fastapi_app.Github") as MockGithub:
+        instance = MockGithub.return_value
+        instance.get_user.return_value = mock_user
+        response = client.get("/repos/repo1", params={"token": "fake"})
+
+    assert response.status_code == 200
+    assert response.json() == {
         "name": "repo1",
-        "full_name": "user/repo1",
-        "html_url": "https://github.com/user/repo1"
-    }]
+        "description": "A repo",
+        "visibility": "public",
+        "default_branch": "main",
+        "branches": ["main", "dev"],
+        "last_commit": {
+            "sha": "abc123",
+            "message": "init",
+            "author": "author",
+            "date": "2024-01-01",
+        },
+        "contributors": ["contrib"],
+        "html_url": "https://github.com/user/repo1",
+    }
+
+
+def test_get_repository_readme():
+    client = TestClient(app)
+
+    readme = MagicMock()
+    readme.decoded_content = b"# Title"
+
+    mock_repo = MagicMock()
+    mock_repo.get_readme.return_value = readme
+
+    mock_user = MagicMock()
+    mock_user.get_repo.return_value = mock_repo
+
+    with patch("fastapi_app.Github") as MockGithub:
+        instance = MockGithub.return_value
+        instance.get_user.return_value = mock_user
+        response = client.get("/repos/repo1/readme", params={"token": "fake"})
+
+    assert response.status_code == 200
+    assert response.json() == {"content": "# Title"}
+
+
+def test_list_local_repositories(tmp_path):
+    client = TestClient(app)
+
+    repo_dir = tmp_path / "repo1"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    # Patch LOCAL_REPOS_DIR to our temporary path
+    original_path = fastapi_app.LOCAL_REPOS_DIR
+    fastapi_app.LOCAL_REPOS_DIR = tmp_path
+
+    response = client.get("/local/repos")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {"name": "repo1", "path": str(repo_dir)}
+    ]
+
+    # restore
+    fastapi_app.LOCAL_REPOS_DIR = original_path
+


### PR DESCRIPTION
## Summary
- expand `/repos` to include description, visibility and default branch
- add endpoints for repo details, README retrieval and local clone listing
- cover new API features with tests

## Testing
- `pytest -q` *(fails: NameError: name '_get_origin_url' is not defined, and other failures in existing tests)*
- `PYTHONPATH=. pytest tests/test_fastapi_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b261a6a96c832da28ab4d6059ad8de