### PR TITLE
Add README display support to repositories UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+!/frontend/src/lib/
+!/frontend/src/lib/**
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/RepistoryDashboard_TD.txt
+++ b/RepistoryDashboard_TD.txt
@@ -1,0 +1,70 @@
+Technical Description: Repository Dashboard Prototype
+1. Overview
+This document describes a single-file HTML prototype for a Git repository dashboard. The prototype is a static, non-functional visual blueprint designed to guide the development of a dynamic web application. It uses placeholder data to illustrate the layout and user interface for managing a single repository.
+Key Technologies:
+HTML5: For the core structure and content.
+Tailwind CSS: For the primary utility-first styling framework, loaded via a CDN.
+Custom Inline CSS: A small <style> block in the <head> defines the base theme (colors, fonts), a reusable .card component style, and other minor global styles.
+2. Page Structure & Layout
+The dashboard is built on a responsive, multi-column grid system that adapts to different screen sizes.
+Main Container: A max-w-7xl container centers the content with horizontal padding that adjusts for mobile (p-4), tablet (sm:p-6), and desktop (lg:p-8) views.
+Header (<header>): This section contains the Repository Overview component. It is a full-width block at the top of the page.
+Dashboard Grid: The main content area is a CSS Grid (grid) that organizes the various dashboard cards.
+On large screens (lg:), it's a 3-column layout. On extra-large screens (xl:), it expands to 4 columns.
+On smaller screens, the columns stack vertically (grid-cols-1).
+Specific components span multiple columns (e.g., lg:col-span-2) to create a balanced, masonry-style layout.
+3. Component Breakdown
+The UI is divided into distinct, card-based components. Each card shares a common style defined by the .card class.
+3.1. Repository Overview (Header)
+This is the main context-setting component.
+Identification: Displays the repository name and description.
+Actions: Includes a placeholder "Push Changes" button.
+Local State Panel: This is the most critical interactive element in the header. It's designed to reflect three distinct states of the local repository relative to the remote. In the prototype, these states are implemented as commented-out HTML blocks. Only one state should be uncommented at a time for preview.
+State 1: Not Cloned: Shows a "Local Status: Not Found" message and a primary "Clone Repository" button. The branch selector and commit info are hidden.
+State 2: Synced: Displays the current branch, a "Synced" status indicator (green checkmark), and the last commit information.
+State 3: Out of Sync (Default View): Shows the current branch, sync status with "Ahead" (green) and "Behind" (red) commit counts, and last commit info.
+3.2. Git Commands Helper
+Purpose: Provides quick access to common Git commands.
+Structure:
+A "Contextual Suggestion" section highlights a recommended command based on the repository's state (e.g., git pull --rebase).
+A collapsible <details> element contains a list of frequently used commands (pull, push, stash), each with a "copy" button icon.
+Commands are styled with a monospace font (Fira Code) for readability.
+3.3. Task/Workflow Panel
+Purpose: To surface pending tasks and recurring chores.
+Structure: A two-column grid within the card separates:
+Open PRs & Issues: A list of links with status dots (green for open PRs, yellow for issues).
+Recurring DevOps: A checklist of common maintenance tasks (e.g., "Update dependencies").
+3.4. Commit & Diff Tools
+Purpose: To inspect recent changes.
+Structure:
+A scrollable list displays recent commits with the message, short SHA, author, and timestamp.
+A footer contains action buttons for "Quick-diff vs main" and "View Staged Changes."
+3.5. Branch & PR Management
+Purpose: To visualize and manage branches.
+Structure:
+An inline SVG serves as a placeholder for a visual branch graph.
+Footer buttons provide quick actions like "New Branch from main" and "Delete Stale Branches."
+3.6. CI/CD & Health Monitor
+Purpose: To provide a quick overview of repository health.
+Structure: A simple key-value list displaying metrics like "Last GitHub Actions run," "Test Coverage," and "Docker Build Status," complete with color-coded status indicators.
+3.7. Notes & Snippets (Captain's Log)
+Purpose: A personal scratchpad for the repository.
+Structure:
+A <textarea> for free-form personal notes.
+A "Saved Snippets" section to store useful one-liners or custom commands.
+3.8. AI Assistant Hooks
+Purpose: To integrate with an external AI/GPT tool.
+Structure:
+Styled with a distinct blue border to indicate its special function.
+Contains action buttons like "Explain recent error..." and "Suggest next step..."
+Includes a "Daily Brief" section to display AI-generated summaries.
+4. Styling & Theming
+Color Palette: A dark theme inspired by code editors, using a base background of #0d1117 and card backgrounds of #161b22. Borders are a subtle #30363d.
+Typography:
+Inter: Used for all standard UI text.
+Fira Code: Used for all code snippets, commit SHAs, and branch names to improve readability.
+Buttons & Interactivity:
+.btn: A base class for standard buttons.
+.btn-primary: A modifier for primary actions (e.g., "Clone," "Push"), styled in green.
+Standard buttons have a subtle hover effect (background-color change), but the main .card components do not change on hover to maintain a stable, non-distracting UI.
+This specification provides a complete overview of the static prototype, ready for a developer to begin implementing the necessary JavaScript logic to create a fully functional dashboard.

--- a/RepositoryCard_TD.txt
+++ b/RepositoryCard_TD.txt
@@ -1,0 +1,48 @@
+Technical description of a single repository card component, breaking down its structure, styling, and data mapping.
+
+1. Main Container (<div>)
+This is the root element of the card.
+
+Structure: A div element acting as a flex container with a vertical direction (flex flex-col). This allows the card body to grow and push the footer to the bottom.
+
+Styling:
+
+bg-gray-800/50: A semi-transparent dark gray background.
+
+border border-gray-700: A subtle border.
+
+rounded-lg p-6: Rounded corners and internal padding.
+
+shadow-lg: A standard box shadow for depth.
+
+Interactivity: hover: pseudo-classes (hover:shadow-blue-500/20, hover:border-blue-500/50) change the border and shadow color on mouseover, providing visual feedback.
+
+Animation: The card-enter class is initially applied. JavaScript then adds card-enter-active to trigger a CSS transition that fades the card in and slides it up slightly for a smooth loading effect.
+
+2. Card Body (<div class="flex-grow">)
+This section contains the primary information about the repository. The flex-grow class ensures it expands to fill available vertical space.
+
+Header: A flex container (flex justify-between) that holds:
+
+Repository Name (<h3> -> <a>): A clickable link that opens the repository's GitHub page in a new tab (target="_blank"). The text content is mapped from the repo.name property of the API response.
+
+Language Badge (<span>): This element is rendered conditionally. If the repo.language property exists in the API data, a styled pill-like badge is displayed. Otherwise, nothing is rendered.
+
+Description (<p>):
+
+Displays the text from the repo.description property.
+
+Fallback: It uses a JavaScript logical OR (||) to display "No description provided." if the description field is null or empty.
+
+Sizing: min-h-[40px] is applied to ensure a consistent card height across the grid, preventing layout shifts caused by varying description lengths.
+
+3. Card Footer (<div>)
+This section at the bottom displays repository metadata and is separated from the body by a top border (border-t).
+
+Layout: A flex container (flex items-center) to align the metadata icons and text horizontally.
+
+Last Updated (<span>):
+
+This is pushed to the far right using ml-auto (margin-left: auto).
+
+The repo.updated_at value (an ISO 8601 timestamp string) is converted into a JavaScript Date object and formatted to a more readable local date string using .toLocaleDateString().

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -15,6 +15,9 @@ class Repository(BaseModel):
     description: Optional[str]
     visibility: str
     default_branch: str
+    language: Optional[str]
+    updated_at: Optional[str]
+    html_url: str
 
 
 class CommitMetadata(BaseModel):
@@ -71,7 +74,7 @@ def get_github_client(token: Optional[str] = Query(default=None, description="Gi
 
 
 BASE_DIR = Path(__file__).resolve().parent
-LOCAL_REPOS_DIR = Path(os.getenv("LOCAL_REPOS_DIR", BASE_DIR.parent / "local_repos")).resolve()
+LOCAL_REPOS_DIR = Path(os.getenv("LOCAL_REPOS_DIR", BASE_DIR / "local_repos")).resolve()
 LOCAL_REPOS_DIR.mkdir(parents=True, exist_ok=True)
 
 @app.middleware("http")
@@ -104,6 +107,9 @@ def list_repositories(gh: Github = Depends(get_github_client)) -> List[Repositor
                 description=r.description,
                 visibility="private" if r.private else "public",
                 default_branch=r.default_branch,
+                language=r.language,
+                updated_at=str(r.updated_at) if r.updated_at else None,
+                html_url=r.html_url,
             )
             for r in user.get_repos()
         ]

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -24,3 +24,15 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Card enter animation */
+.card-enter {
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+}
+
+.card-enter-active {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/frontend/src/app/repositories/[name]/readme/page.tsx
+++ b/frontend/src/app/repositories/[name]/readme/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useSearchParams } from "next/navigation";
+
+import LoadingSpinner from "@/components/LoadingSpinner";
+import ErrorMessage from "@/components/ErrorMessage";
+import { apiClient } from "@/lib/api";
+
+export default function RepositoryReadmePage() {
+  const params = useParams<{ name: string }>();
+  const searchParams = useSearchParams();
+  const [content, setContent] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const repoName = params?.name ?? "";
+  const token = searchParams.get("token") ?? undefined;
+
+  const fetchReadme = useCallback(async () => {
+    if (!repoName) {
+      setError("Repository name is missing.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const readmeContent = await apiClient.getRepositoryReadme(repoName, token);
+      setContent(readmeContent);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load README content"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [repoName, token]);
+
+  useEffect(() => {
+    fetchReadme();
+  }, [fetchReadme]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">
+              {repoName ? `${repoName} README` : "Repository README"}
+            </h1>
+            <p className="text-gray-600">
+              View the README content fetched from your GitHub repository.
+            </p>
+          </div>
+          <Link
+            href="/repositories"
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200"
+          >
+            Back to Repositories
+          </Link>
+        </div>
+
+        {loading && <LoadingSpinner />}
+
+        {error && (
+          <ErrorMessage
+            title="Error Loading README"
+            message={error}
+            onRetry={fetchReadme}
+          />
+        )}
+
+        {!loading && !error && (
+          <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">
+            <pre className="whitespace-pre-wrap font-mono text-sm text-gray-800">
+              {content || "This repository does not have a README."}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/repositories/page.tsx
+++ b/frontend/src/app/repositories/page.tsx
@@ -41,27 +41,27 @@ export default function RepositoriesPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-900 py-8">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          <h1 className="text-3xl font-bold text-white mb-2">
             GitHub Repositories
           </h1>
-          <p className="text-gray-600">
+          <p className="text-gray-300">
             View and manage your GitHub repositories
           </p>
         </div>
 
         {/* GitHub Token Input */}
-        <div className="bg-white rounded-lg shadow-md p-6 mb-8">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        <div className="bg-gray-800/50 border border-gray-700 rounded-lg shadow-md p-6 mb-8">
+          <h2 className="text-lg font-semibold text-white mb-4">
             GitHub Authentication
           </h2>
           <form onSubmit={handleTokenSubmit} className="flex gap-4">
             <div className="flex-1">
               <label
                 htmlFor="github-token"
-                className="block text-sm font-medium text-gray-700 mb-2"
+                className="block text-sm font-medium text-gray-300 mb-2"
               >
                 GitHub Personal Access Token
               </label>
@@ -71,9 +71,9 @@ export default function RepositoriesPage() {
                 value={githubToken}
                 onChange={(e) => setGithubToken(e.target.value)}
                 placeholder="Enter your GitHub token (optional)"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                className="w-full px-3 py-2 border border-gray-600 bg-gray-700 text-white rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 placeholder-gray-400"
               />
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="mt-1 text-sm text-gray-400">
                 Leave empty to use environment variable or provide your token
                 for authentication
               </p>
@@ -101,7 +101,7 @@ export default function RepositoriesPage() {
         )}
 
         {!loading && !error && repositories.length === 0 && (
-          <div className="bg-white rounded-lg shadow-md p-12 text-center">
+          <div className="bg-gray-800/50 border border-gray-700 rounded-lg shadow-md p-12 text-center">
             <svg
               className="w-16 h-16 text-gray-400 mx-auto mb-4"
               fill="none"
@@ -116,10 +116,10 @@ export default function RepositoriesPage() {
                 d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
               />
             </svg>
-            <h3 className="text-lg font-medium text-gray-900 mb-2">
+            <h3 className="text-lg font-medium text-white mb-2">
               No repositories found
             </h3>
-            <p className="text-gray-600">
+            <p className="text-gray-300">
               Make sure you have a valid GitHub token and try again.
             </p>
           </div>
@@ -128,14 +128,14 @@ export default function RepositoriesPage() {
         {!loading && !error && repositories.length > 0 && (
           <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold text-gray-900">
+              <h2 className="text-xl font-semibold text-white">
                 Your Repositories ({repositories.length})
               </h2>
             </div>
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {repositories.map((repo) => (
+              {repositories.map((repo, index) => (
                 <RepositoryCard
-                  key={repo.full_name}
+                  key={repo.full_name || repo.name || `repo-${index}`}
                   repository={repo}
                   token={activeToken}
                 />

--- a/frontend/src/app/repositories/page.tsx
+++ b/frontend/src/app/repositories/page.tsx
@@ -12,6 +12,7 @@ export default function RepositoriesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [githubToken, setGithubToken] = useState("");
+  const [activeToken, setActiveToken] = useState<string | undefined>(undefined);
 
   const fetchRepositories = async (token?: string) => {
     try {
@@ -19,6 +20,7 @@ export default function RepositoriesPage() {
       setError(null);
       const repos = await apiClient.getRepositories(token);
       setRepositories(repos);
+      setActiveToken(token);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to fetch repositories"
@@ -34,9 +36,8 @@ export default function RepositoriesPage() {
 
   const handleTokenSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (githubToken.trim()) {
-      fetchRepositories(githubToken.trim());
-    }
+    const trimmedToken = githubToken.trim();
+    fetchRepositories(trimmedToken ? trimmedToken : undefined);
   };
 
   return (
@@ -95,7 +96,7 @@ export default function RepositoriesPage() {
         {error && (
           <ErrorMessage
             message={error}
-            onRetry={() => fetchRepositories(githubToken || undefined)}
+            onRetry={() => fetchRepositories(activeToken)}
           />
         )}
 
@@ -133,7 +134,11 @@ export default function RepositoriesPage() {
             </div>
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {repositories.map((repo) => (
-                <RepositoryCard key={repo.full_name} repository={repo} />
+                <RepositoryCard
+                  key={repo.full_name}
+                  repository={repo}
+                  token={activeToken}
+                />
               ))}
             </div>
           </div>

--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -1,9 +1,14 @@
 interface ErrorMessageProps {
   message: string;
   onRetry?: () => void;
+  title?: string;
 }
 
-export default function ErrorMessage({ message, onRetry }: ErrorMessageProps) {
+export default function ErrorMessage({
+  message,
+  onRetry,
+  title = "Error Loading Repositories",
+}: ErrorMessageProps) {
   return (
     <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
       <div className="flex flex-col items-center">
@@ -21,9 +26,7 @@ export default function ErrorMessage({ message, onRetry }: ErrorMessageProps) {
             d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
           />
         </svg>
-        <h3 className="text-lg font-medium text-red-800 mb-2">
-          Error Loading Repositories
-        </h3>
+        <h3 className="text-lg font-medium text-red-800 mb-2">{title}</h3>
         <p className="text-red-600 mb-4">{message}</p>
         {onRetry && (
           <button

--- a/frontend/src/components/RepositoryCard.tsx
+++ b/frontend/src/components/RepositoryCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Repository } from "@/types/repository";
+import { useEffect, useRef } from "react";
 
 interface RepositoryCardProps {
   repository: Repository;
@@ -7,59 +8,67 @@ interface RepositoryCardProps {
 }
 
 export default function RepositoryCard({ repository, token }: RepositoryCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  
   const readmeHref = token
     ? `/repositories/${encodeURIComponent(repository.name)}/readme?token=${encodeURIComponent(token)}`
     : `/repositories/${encodeURIComponent(repository.name)}/readme`;
 
+  const formatLastUpdated = (dateString?: string) => {
+    if (!dateString) return "Unknown";
+    return new Date(dateString).toLocaleDateString();
+  };
+
+  useEffect(() => {
+    // Trigger the card enter animation
+    const timer = setTimeout(() => {
+      if (cardRef.current) {
+        cardRef.current.classList.add('card-enter-active');
+      }
+    }, 100);
+    
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
-    <div className="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 p-6 border border-gray-200">
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <h3 className="text-lg font-semibold text-gray-900 mb-2">
-            {repository.name}
+    <div ref={cardRef} className="flex flex-col bg-gray-800/50 border border-gray-700 rounded-lg p-6 shadow-lg hover:shadow-blue-500/20 hover:border-blue-500/50 transition-all duration-200 card-enter">
+      {/* Card Body */}
+      <div className="flex-grow">
+        {/* Header */}
+        <div className="flex justify-between items-start mb-4">
+          <h3 className="text-lg font-semibold text-white">
+            <a
+              href={repository.html_url || `https://github.com/${repository.name}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-blue-400 transition-colors duration-200"
+            >
+              {repository.name}
+            </a>
           </h3>
-          <p className="text-sm text-gray-600 mb-4">{repository.full_name}</p>
+          {repository.language && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-900/50 text-blue-300 border border-blue-700/50">
+              {repository.language}
+            </span>
+          )}
         </div>
-        <div className="flex-shrink-0 ml-4 flex flex-col space-y-2">
-          <a
-            href={repository.html_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200"
-          >
-            View on GitHub
-            <svg
-              className="ml-2 -mr-1 w-4 h-4"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fillRule="evenodd"
-                d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </a>
-          <Link
-            href={readmeHref}
-            className="inline-flex items-center justify-center px-4 py-2 border border-blue-600 text-sm font-medium rounded-md text-blue-600 bg-white hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200"
-          >
-            Display README
-            <svg
-              className="ml-2 -mr-1 w-4 h-4"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4 3a1 1 0 011-1h10a1 1 0 011 1v14a1 1 0 01-1.555.832L10 14.333l-4.445 3.499A1 1 0 014 17V3z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </Link>
+
+        {/* Description */}
+        <p className="text-gray-300 text-sm min-h-[40px] mb-4">
+          {repository.description || "No description provided."}
+        </p>
+      </div>
+
+      {/* Card Footer */}
+      <div className="border-t border-gray-700 pt-4 flex items-center">
+        <div className="flex items-center space-x-4 text-xs text-gray-400">
+          <span className="capitalize">{repository.visibility}</span>
+          <span>•</span>
+          <span>{repository.default_branch}</span>
         </div>
+        <span className="ml-auto text-xs text-gray-400">
+          Updated {formatLastUpdated(repository.updated_at)}
+        </span>
       </div>
     </div>
   );

--- a/frontend/src/components/RepositoryCard.tsx
+++ b/frontend/src/components/RepositoryCard.tsx
@@ -1,10 +1,16 @@
+import Link from "next/link";
 import { Repository } from "@/types/repository";
 
 interface RepositoryCardProps {
   repository: Repository;
+  token?: string;
 }
 
-export default function RepositoryCard({ repository }: RepositoryCardProps) {
+export default function RepositoryCard({ repository, token }: RepositoryCardProps) {
+  const readmeHref = token
+    ? `/repositories/${encodeURIComponent(repository.name)}/readme?token=${encodeURIComponent(token)}`
+    : `/repositories/${encodeURIComponent(repository.name)}/readme`;
+
   return (
     <div className="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 p-6 border border-gray-200">
       <div className="flex items-start justify-between">
@@ -14,7 +20,7 @@ export default function RepositoryCard({ repository }: RepositoryCardProps) {
           </h3>
           <p className="text-sm text-gray-600 mb-4">{repository.full_name}</p>
         </div>
-        <div className="flex-shrink-0 ml-4">
+        <div className="flex-shrink-0 ml-4 flex flex-col space-y-2">
           <a
             href={repository.html_url}
             target="_blank"
@@ -35,6 +41,24 @@ export default function RepositoryCard({ repository }: RepositoryCardProps) {
               />
             </svg>
           </a>
+          <Link
+            href={readmeHref}
+            className="inline-flex items-center justify-center px-4 py-2 border border-blue-600 text-sm font-medium rounded-md text-blue-600 bg-white hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200"
+          >
+            Display README
+            <svg
+              className="ml-2 -mr-1 w-4 h-4"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                d="M4 3a1 1 0 011-1h10a1 1 0 011 1v14a1 1 0 01-1.555.832L10 14.333l-4.445 3.499A1 1 0 014 17V3z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,52 @@
+import { ApiError, Repository, ReadmeResponse } from "@/types/repository";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") || "http://localhost:8000";
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let errorMessage = "Request failed";
+    try {
+      const errorBody = (await response.json()) as Partial<ApiError>;
+      if (errorBody.detail) {
+        errorMessage = errorBody.detail;
+      }
+    } catch {
+      // Ignore JSON parsing errors and use default message
+    }
+    throw new Error(errorMessage);
+  }
+
+  return (await response.json()) as T;
+}
+
+class ApiClient {
+  async getRepositories(token?: string): Promise<Repository[]> {
+    const url = new URL(`${API_BASE_URL}/repos`);
+    if (token) {
+      url.searchParams.set("token", token);
+    }
+
+    const response = await fetch(url.toString(), {
+      cache: "no-store",
+    });
+
+    return handleResponse<Repository[]>(response);
+  }
+
+  async getRepositoryReadme(name: string, token?: string): Promise<string> {
+    const url = new URL(`${API_BASE_URL}/repos/${encodeURIComponent(name)}/readme`);
+    if (token) {
+      url.searchParams.set("token", token);
+    }
+
+    const response = await fetch(url.toString(), {
+      cache: "no-store",
+    });
+
+    const data = await handleResponse<ReadmeResponse>(response);
+    return data.content;
+  }
+}
+
+export const apiClient = new ApiClient();

--- a/frontend/src/types/repository.ts
+++ b/frontend/src/types/repository.ts
@@ -7,3 +7,7 @@ export interface Repository {
 export interface ApiError {
   detail: string;
 }
+
+export interface ReadmeResponse {
+  content: string;
+}

--- a/frontend/src/types/repository.ts
+++ b/frontend/src/types/repository.ts
@@ -1,7 +1,12 @@
 export interface Repository {
   name: string;
-  full_name: string;
-  html_url: string;
+  full_name?: string;
+  html_url?: string;
+  description?: string;
+  visibility: string;
+  default_branch: string;
+  language?: string;
+  updated_at?: string;
 }
 
 export interface ApiError {


### PR DESCRIPTION
## Summary
- add an API client to communicate with the FastAPI backend for repositories and README content
- expose a README viewer page and button from each repository card while passing along the active token
- allow custom error titles to support the README view messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb707f1668832daebc9169301cbce7